### PR TITLE
Add installation guide

### DIFF
--- a/pages/submarine/index.mdx
+++ b/pages/submarine/index.mdx
@@ -79,18 +79,3 @@ Alternatively, you can create your own partition to install submarine to. Start 
 After installing submarine to an external drive, plug in your drive with submarine to your device while powered off, then power it on. On the developer mode screen, press Ctrl + U to boot from external storage. If all goes well, you should soon see the submarine boot menu.
 
 If you run into any issues, please report them. Include the model of your device, which can be found on the developer mode screen.
-
-## Installing linux to the drive
-
-(This example is based on LMDE6, but it should work for any other distro)
-First, ensure that you disk uses a GPT partition table.
-Now, create a 16mb partition, this is where submarine will be. Then, you need to add the neccesary flags, `cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX`, dont forget to put the correct values for your disk. Now you can flash `submarine-<arch>.kpart` to this partition!
-Now we get to the part where you install your favourite linux distro! 
-Submarine needs grub to be able to boot the distro, so create a second partition (anywhere from 64-256mb)
-Finally, create a third partition that will house you system. It can be any size but filling the rest of the disk would be most logical.
-Now you can begin installing your system to the drive, proceed with the usual installation until you get to the partition screen. This is where you need to mount the third (system) partition as `/`, and the second (grub) partition as `/boot/efi`.
-If asked, you should download the grub menu to the second partition, as thats where the grub bootloader will lie.
-The rest should be handled by the installer, and once the system finishes, you are ready to use the drive with your chromebook!
-Once the submarine menu boot up and shows the list of options, select the number wich correcsponds to your system.
-
-After installing, you should use [Tree's audio script](https://github.com/WeirdTreeThing/chromebook-linux-audio) to get audio working, note that this will create a new kernel, and sho will have a new entry in the boot menu wich you should select.

--- a/pages/submarine/index.mdx
+++ b/pages/submarine/index.mdx
@@ -79,3 +79,18 @@ Alternatively, you can create your own partition to install submarine to. Start 
 After installing submarine to an external drive, plug in your drive with submarine to your device while powered off, then power it on. On the developer mode screen, press Ctrl + U to boot from external storage. If all goes well, you should soon see the submarine boot menu.
 
 If you run into any issues, please report them. Include the model of your device, which can be found on the developer mode screen.
+
+## Installing linux to the drive
+
+(This example is based on LMDE6, but it should work for any other distro)
+First, ensure that you disk uses a GPT partition table.
+Now, create a 16mb partition, this is where submarine will be. Then, you need to add the neccesary flags, `cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX`, dont forget to put the correct values for your disk. Now you can flash `submarine-<arch>.kpart` to this partition!
+Now we get to the part where you install your favourite linux distro! 
+Submarine needs grub to be able to boot the distro, so create a second partition (anywhere from 64-256mb)
+Finally, create a third partition that will house you system. It can be any size but filling the rest of the disk would be most logical.
+Now you can begin installing your system to the drive, proceed with the usual installation until you get to the partition screen. This is where you need to mount the third (system) partition as `/`, and the second (grub) partition as `/boot/efi`.
+If asked, you should download the grub menu to the second partition, as thats where the grub bootloader will lie.
+The rest should be handled by the installer, and once the system finishes, you are ready to use the drive with your chromebook!
+Once the submarine menu boot up and shows the list of options, select the number wich correcsponds to your system.
+
+After installing, you should use [Tree's audio script](https://github.com/WeirdTreeThing/chromebook-linux-audio) to get audio working, note that this will create a new kernel, and sho will have a new entry in the boot menu wich you should select.

--- a/pages/submarine/lmde.mdx
+++ b/pages/submarine/lmde.mdx
@@ -1,0 +1,14 @@
+## Installing linux to the drive
+
+(This example is based on LMDE6, but it should work for any other distro)
+First, ensure that you disk uses a GPT partition table.
+Now, create a 16mb partition, this is where submarine will be. Then, you need to add the neccesary flags, `cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX`, dont forget to put the correct values for your disk. Now you can flash `submarine-<arch>.kpart` to this partition!
+Now we get to the part where you install your favourite linux distro! 
+Submarine needs grub to be able to boot the distro, so create a second partition (anywhere from 64-256mb)
+Finally, create a third partition that will house you system. It can be any size but filling the rest of the disk would be most logical.
+Now you can begin installing your system to the drive, proceed with the usual installation until you get to the partition screen. This is where you need to mount the third (system) partition as `/`, and the second (grub) partition as `/boot/efi`.
+If asked, you should download the grub menu to the second partition, as thats where the grub bootloader will lie.
+The rest should be handled by the installer, and once the system finishes, you are ready to use the drive with your chromebook!
+Once the submarine menu boot up and shows the list of options, select the number wich correcsponds to your system.
+
+After installing, you should use [Tree's audio script](https://github.com/WeirdTreeThing/chromebook-linux-audio) to get audio working, note that this will create a new kernel, and sho will have a new entry in the boot menu wich you should select.


### PR DESCRIPTION
This adds installation steps as per my personal experience, sadly I don't know how to see the actual result on the devdocs page so maybe the format is a bit incorrect, all I see is a plaintext document :(

I was helped by jaiden.sh on discord, and if the official installation differs from this please correct it, I was simple asked to contribute a guide by jade, and I'm happy to do so :)

Unrelated note: I used Tree's audio script, and now it shows a new entry in the submarine menu (I'm assuming its because it makes a custom kernel), but the audio still doesn't work in this new option or the original one, maybe it has to do something with how grub manages the systems.