### PR TITLE
Add Arch using Submarine install guide

### DIFF
--- a/pages/submarine/_meta.json
+++ b/pages/submarine/_meta.json
@@ -1,5 +1,6 @@
 {
   "index": "Introduction",
   "guide_lmde": "Guide (LMDE)",
-  "guide_debian": "Guide (Debian)"
+  "guide_debian": "Guide (Debian)",
+  "guide_arch": "Guide (Arch)"
 }

--- a/pages/submarine/guide_arch.mdx
+++ b/pages/submarine/guide_arch.mdx
@@ -26,7 +26,7 @@ crossystem dev_boot_signed_only=0
 
 ## Installing
 
-1. After chrooting into the new install, install GRUB. As there is no ESP, skip the `grub-install` step and only run `grub-mkconfig -o /boot/grub/grub.cfg`. You must first create the `/boot/grub` directory otherwise `grub-mkconfig` will fail.
+1. After chrooting into the new install, install the `grub` package. As there is no ESP, skip the `grub-install` step and only run `grub-mkconfig -o /boot/grub/grub.cfg`. You must first create the `/boot/grub` directory otherwise `grub-mkconfig` will fail.
 
 2. Install `curl` or `wget`, and `unzip` in order to download and extract Submarine. Here is the link again: https://nightly.link/FyraLabs/submarine/workflows/build/main/submarine-x86_64.zip
 

--- a/pages/submarine/guide_arch.mdx
+++ b/pages/submarine/guide_arch.mdx
@@ -32,7 +32,7 @@ crossystem dev_boot_signed_only=0
 3. Arch does not package `cgpt`, but it is available in the AUR. Install `git`, and run the following commands
 ```git clone https://aur.archlinux.org/cgpt-bin.git
 cd cgpt-bin
-makepkg -Si
+makepkg -si
 ```
 
 4. As before, set the necessary flags for the Submarine partition on your internal disk.

--- a/pages/submarine/guide_arch.mdx
+++ b/pages/submarine/guide_arch.mdx
@@ -1,0 +1,54 @@
+# Installing Arch Linux with Submarine
+
+## Preparation
+
+1. Write the Arch Linux live ISO to external media.
+
+2. Create a new 16MB partition for Submarine on the external media. If using ChromeOS, `fdisk`/`cfdisk` are installed by default.
+
+3. In ChromeOS, set the necessary flags for the Submarine partition with `cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX`, substituting <partition number> for the number of the Submarine partition and `/dev/sdX` for the block device of your external media.
+
+4. Write `submarine-x86_64.kpart` to the Submarine partition created in step 2.
+
+5. Reminder: to boot Submarine from external media, you first need to run the following commands as root
+```crossystem dev_boot_usb=1
+crossystem dev_boot_signed_only=0
+```
+
+6. Reboot, and on the Developer Mode screen, press Ctrl+U to boot from external media.
+
+## Partitioning
+
+1. After booting the Arch Linux live ISO with Submarine, proceed with the regular manual installation of Arch Linux.
+
+2. When partitioning the internal disk, again create a 16MB partition for Submarine. You do not need to create a EFI system partition (ESP) as Submarine does not use UEFI.
+
+## Installing
+
+1. After chrooting into the new install, install GRUB. As there is no ESP, skip the `grub-install` step and only run `grub-mkconfig -o /boot/grub/grub.cfg`. You must first create the `/boot/grub` directory otherwise `grub-mkconfig` will fail.
+
+2. Install `curl` or `wget`, and `unzip` in order to download and extract Submarine. Here is the link again: https://nightly.link/FyraLabs/submarine/workflows/build/main/submarine-x86_64.zip
+
+3. Arch does not package `cgpt`, but it is available in the AUR. Install `git`, and run the following commands
+```git clone https://aur.archlinux.org/cgpt-bin.git
+cd cgpt-bin
+makepkg -Si
+```
+
+4. As before, set the necessary flags for the Submarine partition on your internal disk.
+
+5. Write `submarine-x86_64.kpart` to the Submarine partition.
+
+6. Proceed with the rest of the Arch Linux installation as described in the installation guide on the ArchWiki.
+
+## Postinstall
+
+After you've finished installing, reboot and press Ctrl+D to boot from internal disk. If you did everything right, you should be looking at the Submarine boot menu. Select the number that corresponds to your system to boot into Arch.
+
+For audio fixes for running Linux on Chromebooks, take a look at [WeirdTreeThing's audio script](https://github.com/WeirdTreeThing/chromebook-linux-audio).
+
+### Note
+
+Fyra Labs is not affiliated with the developers of Arch Linux, this guide is unofficial.
+
+If you're a developer of Arch Linux reading this, and want to make it official, [let us know](mailto:contact@fyralabs.com)!

--- a/pages/submarine/guide_arch.mdx
+++ b/pages/submarine/guide_arch.mdx
@@ -11,7 +11,8 @@
 4. Write `submarine-x86_64.kpart` to the Submarine partition created in step 2.
 
 5. Reminder: to boot Submarine from external media, you first need to run the following commands as root
-```crossystem dev_boot_usb=1
+```bash
+crossystem dev_boot_usb=1
 crossystem dev_boot_signed_only=0
 ```
 
@@ -30,7 +31,8 @@ crossystem dev_boot_signed_only=0
 2. Install `curl` or `wget`, and `unzip` in order to download and extract Submarine. Here is the link again: https://nightly.link/FyraLabs/submarine/workflows/build/main/submarine-x86_64.zip
 
 3. Arch does not package `cgpt`, but it is available in the AUR. Install `git`, and run the following commands
-```git clone https://aur.archlinux.org/cgpt-bin.git
+```bash
+git clone https://aur.archlinux.org/cgpt-bin.git
 cd cgpt-bin
 makepkg -si
 ```

--- a/pages/submarine/index.mdx
+++ b/pages/submarine/index.mdx
@@ -68,7 +68,8 @@ sudo dd if=build/submarine.bin of=/dev/sdX
 
 Before you can boot submarine, you need to enable booting from external storage. On your Chrome device, press Ctrl + Alt + F2 (This will either be the refresh or forward key on the top row) to switch to vt2. Log in as root and run the following commands:
 
-```crossystem dev_boot_usb=1
+```bash
+crossystem dev_boot_usb=1
 crossystem dev_boot_signed_only=0
 ```
 


### PR DESCRIPTION
I've written this guide to show how it's possible to use Submarine without the need to create a ESP when installing a distro that has a manual installation process