### PR TITLE
fix(submarine): update minimal partition size; minor wording

### DIFF
--- a/pages/submarine/guide_arch.mdx
+++ b/pages/submarine/guide_arch.mdx
@@ -4,9 +4,9 @@
 
 1. Write the Arch Linux live ISO to external media.
 
-2. Create a new 16MB partition for Submarine on the external media. If using ChromeOS, `fdisk`/`cfdisk` are installed by default.
+2. Create a new 16MB partition for Submarine on the external media. On aarch64, you need to make it 64MB instead. If using ChromeOS, `fdisk`/`cfdisk` are installed by default.
 
-3. In ChromeOS, set the necessary flags for the Submarine partition with `cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX`, substituting &lt;partition number&gt; for the number of the Submarine partition and `/dev/sdX` for the block device of your external media.
+3. Set the necessary flags for the Submarine partition with `cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX`, substituting &lt;partition number&gt; for the number of the Submarine partition and `/dev/sdX` for the block device of your external media.
 
 4. Write `submarine-x86_64.kpart` to the Submarine partition created in step 2.
 
@@ -22,7 +22,7 @@ sudo enable_dev_usb_boot
 
 1. After booting the Arch Linux live ISO with Submarine, proceed with the regular manual installation of Arch Linux.
 
-2. When partitioning the internal disk, again create a 16MB partition for Submarine. You do not need to create a EFI system partition (ESP) as Submarine does not use UEFI.
+2. When partitioning the internal disk, again create a 16MB/64MB partition for Submarine. You do not need to create a EFI system partition (ESP) as Submarine does not use UEFI.
 
 ## Installing
 

--- a/pages/submarine/guide_debian.mdx
+++ b/pages/submarine/guide_debian.mdx
@@ -8,13 +8,13 @@ import { Callout } from 'nextra/components';
 
 Ensure that your disk uses a GPT partition table.
 
-1. Create a 16 MB partition to store Submarine.
+1. Create a 16MB partition to store Submarine. If you're on aarch64, make it 64MB instead.
   
 2. Add the necessary flags by using `cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX`, don't forget to change the partition number and block device for your disk.
 
 3. Flash `submarine-<arch>.kpart` to the partition you just made.
 
-4. Create a second partition to store GRUB, this can be from 64 MB to 256 MB.
+4. Create a second partition to store GRUB, this can be from 64 to 256 MB.
 
 5. Last, create a third partition to store the root of your system. It needs to be at least 10 GB, but it would be most logical to fill up the rest of the disk with it.
 

--- a/pages/submarine/guide_lmde.mdx
+++ b/pages/submarine/guide_lmde.mdx
@@ -4,7 +4,7 @@
 
 Ensure that your disk uses a GPT partition table.
 
-1. Create a 16mb partition, this is where Submarine will be.
+1. Create a 16MB partition for Submarine. If you're on aarch64, make it 64MB instead.
 
 2. Add the neccesary flags with `cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX`, dont forget to put the correct values for your disk.
 

--- a/pages/submarine/index.mdx
+++ b/pages/submarine/index.mdx
@@ -8,8 +8,8 @@ description: Bootstrap a Linux system on Depthcharge with Submarine
 # Submarine
 ### Experimental bootloader for ChromeOS' Depthcharge
 
-Submarine provides a minimal Linux environment that lives in a small partition (16mb) on the disk. 
-This is used to boot into a full Linux distro using kexec.
+Submarine provides a minimal Linux environment that lives in a small partition (16MB) on the disk.
+This is used to boot into a full Linux distro through kexec.
 
 
 ## Prebuilt Images
@@ -74,7 +74,7 @@ sudo enable_dev_usb_boot
 
 For quick testing, you can flash `submarine-<arch>.bin` to an external drive. This image includes a partition table already set up for booting ChromeOS kernels.
 
-Alternatively, you can create your own partition to install submarine to. Start by creating a 16mb EXT4 partition. Next you will edit the partition flags to tell depthcharge that you can boot from that partition by running the following command:
+Alternatively, you can create your own partition to install submarine to. Start by creating an EXT4 partition (16MB for x86_64, 64MB for aarch64). Next you will edit the partition flags to tell depthcharge that you can boot from that partition by running the following command:
 
 ```bash
 cgpt add -i <partition number> -t kernel -P 15 -T 1 -S 1 /dev/sdX


### PR DESCRIPTION
currently, the kpart is.. somewhat bigger than the previously claimed 16MB :)

```
$ du -sh submarine-a64.kpart 
36.1M	submarine-a64.kpart
```

haven't checked x86, but i think it'll be much less confusing if we have just one size everywhere. 

other than changing the minimal size i've corrected a few words that stood out as weird.