### PR TITLE
link to archive of dont-ship.it

### DIFF
--- a/pages/terra/policy.mdx
+++ b/pages/terra/policy.mdx
@@ -60,7 +60,7 @@ Packagers and maintainers MUST follow the policies and guidelines listed in this
     10. `langs/` (software written in/for a specific programming language)
 - When there are ambiguous or unspecified parts in our policies/guidelines, you SHOULD refer to [Fedora's packaging guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines).
 - Low-quality contributions will be declined at the team's discretion.
-- Do not include work-in-progress code or untested patches. See https://dont-ship.it/.
+- Do not include work-in-progress code or untested patches. See [dont-ship.it](https://archive.is/9zDrU).
 
 ## Maintenance Policy
 


### PR DESCRIPTION
the domain registration seems to have lapsed;  
there is also the wayback archive if that is preferred: https://web.archive.org/web/20250320104139/https://dont-ship.it/

or maybe removing it is the move