### PR TITLE
chore: %__yarn_dlx

### DIFF
--- a/pages/terra/srpm.mdx
+++ b/pages/terra/srpm.mdx
@@ -55,6 +55,7 @@ For other macros available in Fedora/Terra, check out our unofficial [macros lis
 | `%pnpm_approve_builds`          | Approve dependency scripts if needed                                   |
 | `%yarn_common_envvars`          |                                                                        |
 | `%__yarn`                       | `/usr/bin/env %{yarn_common_envvars} /usr/bin/yarn`                    |
+| `%__yarn_dlx`                   |                                                                        |
 | `%yarn_build`                   | yarn build                                                             |
 | `%yarn_audit`                   | Audit yarn if package uses bundled Node dependencies. For use in the `%check` section |
 | `electronmeta`                  |                                                                        |


### PR DESCRIPTION
I realized later it was kinda stupid to have all the other `x` functions as macros but not *something* for Yarn's, so adding it here too.