### PR TITLE
fix: Dead Policy Link

### DIFF
--- a/pages/terra/contributing.mdx
+++ b/pages/terra/contributing.mdx
@@ -186,7 +186,7 @@ dependencies using `[1;32msudo dnf[97m builddep [0;97;mpath/to/pkgname.spec{:
 
 ## Done?
 
-- Review our [policies](/terra/policy) and [guidelines](/terra/guidelines)
+- Review our [policies](/terra/policies) and [guidelines](/terra/guidelines)
 - Git commit and push; remember you must sign your commits!
 - Create a pull request that merges to the `frawhide` branch, this is equivalent to main or master
 


### PR DESCRIPTION
This fixes the dead policy link in contributing.

This is a draft because this change has not been discussed.
