### PR TITLE
fix(anda): mock cache is stored in `/var/cache` instead of `/var/lib`

### DIFF
--- a/content/docs/terra/contributing.mdx
+++ b/content/docs/terra/contributing.mdx
@@ -77,7 +77,7 @@ If you're on atomic system, or otherwise prefer to work with containers, you can
 Simply run:
 
 ```shell
-podman run --rm --cap-add=SYS_ADMIN --privileged --volume ./:/anda --volume mock_cache:/var/lib/mock --workdir /anda ghcr.io/terrapkg/builder:frawhide anda`
+podman run --rm --cap-add=SYS_ADMIN --privileged --volume ./:/anda --volume mock_cache:/var/cache/mock --workdir /anda ghcr.io/terrapkg/builder:frawhide anda`
 ```
 
 #### Cargo


### PR DESCRIPTION
At least it seems to be the case on my device

<img width="819" height="262" alt="image" src="https://github.com/user-attachments/assets/374039e0-41d0-4830-ac6a-04646a624a70" />
<img width="619" height="602" alt="image" src="https://github.com/user-attachments/assets/19c00784-09c9-41da-a1d1-04ba36572043" />
<img width="619" height="602" alt="image" src="https://github.com/user-attachments/assets/db269f3e-6e30-421f-b199-18c7b47b3995" />
