### PR TITLE
Change description for swapping Mesa

### DIFF
--- a/content/docs/terra/installing.mdx
+++ b/content/docs/terra/installing.mdx
@@ -141,7 +141,7 @@ Run the following to enable `terra-mesa`:
 sudo dnf install terra-release-mesa
 ```
 
-If you already have stock `mesa` installed, run the following command to swap it to `terra-mesa` after enabling the repo:
+If you have `mesa-va-drivers-freeworld` installed from RPMFusion, run the following command to swap it to Terra's `mesa-va-drivers` after enabling the repo:
 
 ```sh
 sudo dnf swap mesa-va-drivers-freeworld mesa-va-drivers


### PR DESCRIPTION
hi, fox here. i for some reason thought that `mesa-va-drivers-freeworld` was a stock fedora package but it's only in rpmfusion and is deprecated now so i changed the wording in the instructions.
sorry my commit is unverified i did it in github and didn't feel like doing this properly